### PR TITLE
Allow running as a module

### DIFF
--- a/rummy/__main__.py
+++ b/rummy/__main__.py
@@ -1,0 +1,3 @@
+from rummy import command_line
+
+command_line.main()

--- a/rummy/game/score.py
+++ b/rummy/game/score.py
@@ -3,7 +3,7 @@
 from ansi_colours import AnsiColours as Colour
 from text_template import TextTemplate as View
 
-from constants.resource_path import TEMPLATE_PATH
+from rummy.constants.resource_path import TEMPLATE_PATH
 
 
 class Score:

--- a/rummy/player/ai.py
+++ b/rummy/player/ai.py
@@ -4,7 +4,7 @@ from time import sleep
 
 from text_template import TextTemplate as View
 
-from constants.resource_path import TEMPLATE_PATH
+from rummy.constants.resource_path import TEMPLATE_PATH
 from rummy.player.player import Player
 
 

--- a/rummy/player/player.py
+++ b/rummy/player/player.py
@@ -4,7 +4,7 @@ from abc import ABCMeta, abstractmethod
 
 from text_template import TextTemplate as View
 
-from constants.resource_path import TEMPLATE_PATH
+from rummy.constants.resource_path import TEMPLATE_PATH
 from rummy.game.melds import Melds
 from rummy.player.hand import Hand
 


### PR DESCRIPTION
happy hacktoberfest :wave: :jack_o_lantern: :fallen_leaf: !

This add's a `__main__.py` file to allow running `rummy` without installing.

```shell
git clone https://github.com/sarcoma/Python-Rummy.git
cd Python-Rummy
pip install -r requirements.txt
python -m rummy
```

To get this to work I had to load `constants` from `rummy`, but all tests are still passing locally with this change.

Let me know if you also want this documented in the README.